### PR TITLE
Fixed Error 404

### DIFF
--- a/src/app/@modal/default.js
+++ b/src/app/@modal/default.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Default() {
+  return null;
+}


### PR DESCRIPTION
In response to the previous error with Parallel Routes

# You need to understand what's going on here
## How to make Parallel Routes
To create such routes you have to create a slot for route, it is slightly different from route.  Slots are created using `@` convention in directory name, as you did. 

In this directory you have to define path for the route name or path which is being done by creating another directory inside slot directory.  Eg: `@modal/post/` in this path, `modal` is slot name and `post` is route name.

## default.js (You were missing it out)
> Documentation for this file is missing in Next's documentation but it is critical for Parallel route.
https://nextjs.org/docs/app/api-reference/file-conventions/default

In `layout` file when you use `props.modal`, then Next initally renders `default.js` for respective slot, as no route is initally defined. For example if you are in `/` and using Parallel Route on this page. Then Next JS initally renders component returned by `default.js`, and when you navigate to any path for parallel route, as per above example, if you navigate to `/post/` then Next replaces component for `default.js` with the component in respective route ie the component in `/@modal/post/page.js`.

You were facing `Error 404` because Next JS was trying to render `default.js` component in `layout.js` file, but it was missing, hence as convention it renderred component for Error 404 ie `not-found.js` instead.

Hope it help!
PAURUSH SINHA 